### PR TITLE
Add option to outputstream to not emit empty frames

### DIFF
--- a/lib/MumbleConnection.js
+++ b/lib/MumbleConnection.js
@@ -134,8 +134,12 @@ MumbleConnection.prototype.sendMessage = function (type, data) {
  *      Optional user session ID. If omitted the output stream will receive
  *      the mixed audio output for all users.
  **/
-MumbleConnection.prototype.outputStream = function ( userSession ) {
-    var stream = new MumbleOutputStream( this, userSession );
+MumbleConnection.prototype.outputStream = function ( userSession, noEmptyFrames ) {
+    if(typeof userSession === "boolean") {  // To make it possible to create an OutputStream without empty frames without having to specify a session id
+        userSession = undefined;
+        noEmptyFrames = userSession;
+    }
+    var stream = new MumbleOutputStream( this, userSession , { noEmptyFrames : noEmptyFrames });
     return stream;
 };
 

--- a/lib/MumbleOutputStream.js
+++ b/lib/MumbleOutputStream.js
@@ -23,9 +23,14 @@ var MumbleOutputStream = function(connection, sessionId, options) {
     this.frames = [];
 
     this.writtenUntil = Date.now();
+    if(options) {
+        this.noEmptyFrames = options.noEmptyFrames;
+    }
 
-    this.emptyFrame = new Buffer( this.connection.FRAME_SIZE * 2 );
-    this.emptyFrame.fill(0);
+    if(!this.noEmptyFrames) {
+        this.emptyFrame = new Buffer( this.connection.FRAME_SIZE * 2 );
+        this.emptyFrame.fill(0);
+    }
 
     this.voiceListener = function( data ) { self._addAudio( data ); };
 
@@ -81,7 +86,7 @@ MumbleOutputStream.prototype._read = function( size ) {
     if( this.frames.length === 0 ) {
 
         // If we're overdue on written frames, write an empty frame.
-        if( this.writtenUntil + this.connection.FRAME_LENGTH < Date.now() ) {
+        if( !this.noEmptyFrames && this.writtenUntil + this.connection.FRAME_LENGTH < Date.now() ) {
             this.push( this.emptyFrame );
             this.writtenUntil += this.connection.FRAME_LENGTH;
             return;

--- a/lib/User.js
+++ b/lib/User.js
@@ -80,8 +80,8 @@ User.prototype._checkMute = function(data) {
     this.mute = data.mute;
 };
 
-User.prototype.outputStream = function() {
-    return this.wrapper.connection.outputStream(this.session);
+User.prototype.outputStream = function(noEmptyFrames) {
+    return this.wrapper.connection.outputStream(this.session, noEmptyFrames);
 };
 
 User.prototype.inputStream = function() {


### PR DESCRIPTION
This PR is usable with PR #27 . Added an option to create Outputstreams without empty frames.
This fixes #23 .