### PR TITLE
Propagate permission denied errors

### DIFF
--- a/lib/MumbleConnection.js
+++ b/lib/MumbleConnection.js
@@ -458,6 +458,17 @@ MumbleConnection.prototype._onCodecVersion = function( codecVersion ) {
 };
 
 /**
+ * Propagate permission denied errors
+ *
+ * @private
+ *
+ * @param data Details about the error
+ **/
+MumbleConnection.prototype._onPermissionDenied = function (data) {
+    this.emit('permission-denied', data)
+};
+
+/**
  * Handle ping message
  *
  * @private


### PR DESCRIPTION
Simply emit an event when this occurs.