### PR TITLE
The default value for temporary should be true

### DIFF
--- a/lib/Channel.js
+++ b/lib/Channel.js
@@ -89,6 +89,9 @@ Channel.prototype.addSubChannel = function( name, options ) {
 
     options = options || {};
 
+    // The default for temporary should be true
+    options.temporary = options.temporary !== undefined ? options.temporary : true;
+
     this.client.connection.sendMessage( 'ChannelState', {
 
         parent: this.id,


### PR DESCRIPTION
I was hitting an error where creating a subchannel was firing a permission denied error. It seems like creating a permanent channel is much more likely to hit this and also should require more intent on the part of the developer. Thus I think that the default for adding subchannels should be `temporary: true`.