### PR TITLE
Path is always non-null, only joinPath if length is greater than 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ exports.connect = function( url, options, done ) {
         }
 
         // If path was given, wait for init to be done before moving.
-        if( server.path ) {
+        if( server.path.length ) {
             connection.once('initialized', function () {
                 connection.joinPath( server.path );
             });


### PR DESCRIPTION
This is a bug that happens if you attempt to create a room and join it inside of your own 'initialized' handler. You create the room but then this joinpath puts you back into the root channel. Not joining the room automatically allows you to join or create sub channels, then join them successfully.