### PR TITLE
The done callback should not be callable multiple times

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,9 +60,12 @@ exports.connect = function( url, options, done ) {
                 connection.joinPath( server.path );
             });
         }
+
+        // The connection will now own listening for socket errors.
+        socket.removeListener('error', done);
     });
 
-    socket.on('error', done);
+    socket.once('error', done);
 };
 
 exports.celtVersions = mumbleutil.celtVersions;

--- a/lib/MumbleConnection.js
+++ b/lib/MumbleConnection.js
@@ -26,6 +26,9 @@ var MumbleConnection = function (socket, options) {
     this.socket = new MumbleSocket(socket);
     this.options = options;
     socket.on('close', this.disconnect.bind( this ) );
+    socket.on('error', function (err) {
+        self.emit( 'error', err );
+    })
 
     // Set up the encoders we use for encoding our audio.
     this.opusEncoder = new OpusEncoder( this.SAMPLING_RATE );

--- a/lib/MumbleConnection.js
+++ b/lib/MumbleConnection.js
@@ -28,7 +28,7 @@ var MumbleConnection = function (socket, options) {
     socket.on('close', this.disconnect.bind( this ) );
     socket.on('error', function (err) {
         self.emit( 'error', err );
-    })
+    });
 
     // Set up the encoders we use for encoding our audio.
     this.opusEncoder = new OpusEncoder( this.SAMPLING_RATE );


### PR DESCRIPTION
When I call `connection.disconnect()` it's possible for there to be a socket error regarding writing to a disconnected socket, which is a different issue. 

But when this happens the callback to `mumble.connect` is being called again, which is confusing. This change still calls back done with the error if the error happens while connecting, but once connected the user will have to listen to `connection.on('error', onerror)` to get socket errors  rather than have the done function called back a second time.