### PR TITLE
Add ability to pass tokens on connect for ACL control

### DIFF
--- a/lib/MumbleClient.js
+++ b/lib/MumbleClient.js
@@ -325,9 +325,10 @@ MumbleClient.prototype.inputStreamForUser = function( sessionId, options ) {
  * @param {String} password -
  *      Optional password. Required if the username is in use and certificate
  *      isn't supplied.
+ * @param {String[]} tokens - list of ACL tokens to apply on connection
  */
-MumbleClient.prototype.authenticate = function(name, password) {
-    return this.connection.authenticate(name, password); };
+MumbleClient.prototype.authenticate = function(name, password, tokens) {
+    return this.connection.authenticate(name, password, tokens); };
 
 /**
  * @summary Sends a text message to recipients.

--- a/lib/MumbleConnection.js
+++ b/lib/MumbleConnection.js
@@ -106,11 +106,12 @@ MumbleConnection.prototype.setBitrate = function( bitrate ) {
  *
  * @param name Username
  **/
-MumbleConnection.prototype.authenticate = function( name, password ) {
+MumbleConnection.prototype.authenticate = function( name, password, tokens ) {
     this.sendMessage('Authenticate', {
         username: name,
         password: password,
         opus: true,
+        tokens: tokens || [],
         celt_versions: this.options.celtVersions || util.celtVersions.default
     });
     this.authSent = true;


### PR DESCRIPTION
Adds the ability to pass tokens on authenticate for ACL groups. This is useful for mumble servers that control group and channel permissions with ACL's.