### PR TITLE
Fixes #56. Do not skip voice packages if user is not talking.

### DIFF
--- a/lib/MumbleConnection.js
+++ b/lib/MumbleConnection.js
@@ -803,11 +803,6 @@ MumbleConnection.prototype._dequeueFrames = function() {
     for( var i in this.users ) {
         var user = this.users[i];
 
-        // We don't need to skip the users who aren't talking.
-        if( !user.voiceActive ) {
-            continue;
-        }
-
         // Get the frame for the user
         var frame = user.buffer.get( this.FRAME_LENGTH );
 


### PR DESCRIPTION
We cannot skip incoming packages when the user is not currently talking. Otherwise the first packet of each stream will get lost.