### PR TITLE
Make connection exit properly

### DIFF
--- a/lib/MumbleConnection.js
+++ b/lib/MumbleConnection.js
@@ -409,6 +409,7 @@ MumbleConnection.prototype.sendEncodedFrame = function(
  */
 MumbleConnection.prototype.disconnect = function() {
     clearInterval( this.pingInterval );
+    clearInterval( this.processInterval );
     this.emit( 'disconnect' );
     this.socket.end();
     this.removeAllListeners();


### PR DESCRIPTION
Currently, the connection doesn't stop as the `processInterval` interval is never cleared which keeps application using `node-mumble` running forever.