### PR TITLE
[Typescript Typing] fix EventEmitter reference

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ export interface InputStream extends NodeJS.WritableStream {
     signed: boolean;
     endianness: "BE" | "LE";
     processInterval: NodeJS.Timer;
-    processObserver: EventEmitter;
+    processObserver: NodeJS.EventEmitter;
     frameQueue: Buffer[];
     lastFrame: Buffer;
     lastFrameWritten: number;
@@ -25,7 +25,7 @@ export interface OutputStream extends NodeJS.ReadableStream {
     close: () => void;
     connection: Connection;
     sessionId: number;
-    eventEmitter: EventEmitter;
+    eventEmitter: NodeJS.EventEmitter;
     frames: Buffer[];
     writtenUntil: number;
     noEmptyFrames: boolean;


### PR DESCRIPTION
Typescript 2.8.3 gives me an error, because there is no global EventEmitter name. Alternative fix would be adding an import {EventEmitter} from 'events'.