### PR TITLE
Fixes user.inputStream() and automates typescript declaration file generation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,3 +22,7 @@ Other contributors
 
 - Michael Perrotte <https://github.com/mikemimik>
   - Created MumbleConnectionManager class
+
+- Patrick Pacher <https://github.com/ppacher>
+  - Fixed user.inputStream()
+  - Automated typescript declarion file generation

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,105 +1,641 @@
-/// <reference types="node" />
+import { Socket } from "net"; 
+import { Writable, Readable } from "stream"; 
+declare class Channel {
+    /**
+     * Single channel on the server.
+     * @param data - Channel data.
+     * @param client - Mumble client that owns the channel.
+     */
+    constructor(data: Object, client: MumbleClient);
 
-export interface InputStream extends NodeJS.WritableStream {
-    close: () => void;
-    setGain: (gain: number) => void;
-    connection: Connection;
-    channels: number;
-    whisperId: number;
-    sampleRate: number;
-    gain: number;
-    bitDepth: number;
-    signed: boolean;
-    endianness: "BE" | "LE";
-    processInterval: NodeJS.Timer;
-    processObserver: NodeJS.EventEmitter;
-    frameQueue: Buffer[];
-    lastFrame: Buffer;
-    lastFrameWritten: number;
-    queuedForPlay: number;
-    lastWrite: number;
-    sent: number;
-}
-
-export interface OutputStream extends NodeJS.ReadableStream {
-    close: () => void;
-    connection: Connection;
-    sessionId: number;
-    eventEmitter: NodeJS.EventEmitter;
-    frames: Buffer[];
-    writtenUntil: number;
-    noEmptyFrames: boolean;
-    emptyFrame: Buffer;
-    voiceListener: (data: Buffer) => void;
-}
-export interface Channel {
-    addSubChannel: (name: string, options: any) => void;
-    getPermissions: (callback: () => any) => void;
-    join: () => void;
-    remove: () => void;
-    sendMessage: (message: string) => void;
-    children: Channel[];
     links: Channel[];
+
+    children: Channel[];
+
     users: User[];
-    name: string;
-    id: number;
-    position: number;
+
+    join(): void;
+
+    /**
+     * 
+     * @param message - The message to send.
+     */
+    sendMessage(message: string): void;
+
+    /**
+     * 
+     * @param callback - Result callback
+     */
+    getPermissions(callback: Function): void;
+
+    /**
+     * 
+     * @param name - New sub-channel name.
+     * @param options - Channel options.
+     */
+    addSubChannel(name: string, options: Object): void;
+
+    remove(): void;
+
 }
 
-export interface User {
-    channel: Channel;
-    deaf: boolean;
-    hash: string;
-    id: number;
-    mute: boolean;
-    name: string;
-    prioritySpeaker: boolean;
-    recording: boolean;
-    selfDeaf: boolean;
-    selfMute: boolean;
-    session: number;
-    suppress: boolean;
-    ban: (reason?: string) => void;
-    canHear: () => boolean;
-    canTalk: () => boolean;
-    inputStream: () => InputStream;
-    isRegistered: () => boolean;
-    kick: (reason?: string) => void;
-    moveToChannel: (channel: Channel) => void;
-    outputStream: (noEmptyFrames?: boolean) => OutputStream;
-    sendMessage: (message: string) => void;
-    setComment: (comment: string) => void;
-    setSelfDeaf: (isSelfDeaf: boolean) => void;
-    setSelfMute: (isSelfMute: boolean) => void;
-    on: (event: string, callback: (...args: any[]) => any) => void;
-    once: (event: string, callback: (...args: any[]) => any) => void;
-    register: () => void;
-}
+declare class MumbleClient {
+    /**
+     * 
+     * Instances should be created with Mumble.connect().
+     * @param connection - The underlying connection.
+     */
+    constructor(connection: MumbleConnection);
 
-export interface Options {
-    key?: string;
-    cert?: string;
-    celtVersion?: string;
-}
+    /**
+     * 
+     * The connection is considered `ready` when the server handshake has been
+     * processed and the initial ping has been received.
+     */
+    ready: Boolean;
 
-export interface Connection {
-    authenticate: (username: string, password: string) => void;
-    users: () => User[];
-    channelById: (id: number) => Channel;
-    userById: (id: number) => User;
-    channelByName: (name: string) => Channel;
-    userByName: (name: string) => User;
-    sendMessage: (name: string, data: string) => void;
-    outputStream: (userId?: number) => OutputStream;
-    inputStream: () => InputStream;
-    disconnect: () => void;
-    sendVoice: (chunk: Buffer) => void;
-    on: (event: string, callback: (...args: any[]) => any) => void;
-    once: (event: string, callback: (...args: any[]) => any) => void;
-    ready: boolean;
+    /**
+     * 
+     * The connection object is used for the low level access to the Mumble
+     * protocol. Most developers should find a higher level APIs for the
+     * functionality on the {@link MumbleClient} class instead.
+     */
+    connection: MumbleConnection;
+
     rootChannel: Channel;
+
     user: User;
-    getRegisteredUsers: (callback: (registeredUsers: any[]) => void) => void;
+
+    /**
+     * 
+     * @returns Users connected to the server
+     */
+    users(): User[];
+
+    /**
+     * 
+     * @param id - Channel ID to search for.
+     * @returns The channel found or undefined.
+     */
+    channelById(id: number): Channel;
+
+    /**
+     * 
+     * Every connected user has a session ID. The ID identifies the current
+     * connection and will change when the user reconnects.
+     * @param id - The session ID to search for.
+     * @returns The user found or undefined.
+     */
+    userBySession(id: number): User;
+
+    /**
+     * 
+     * User ID exists only on registered users. The ID will remain the same between
+     * different sessions.
+     * @param id - The user ID to search for.
+     * @returns The user found or undefined.
+     */
+    userById(id: number): User;
+
+    /**
+     * 
+     * @param name - Channel name to search for.
+     * @returns The first channel found or undefined.
+     */
+    channelByName(name: string): Channel;
+
+    /**
+     * 
+     * @param path - Channel path
+     * @returns The channel found or undefined.
+     */
+    channelByPath(path: string): Channel;
+
+    /**
+     * 
+     * @param name - User name to search for.
+     * @returns The user found or undefined.
+     */
+    userByName(name: string): User;
+
+    /**
+     * 
+     * @param callback -
+     *        Will be called with all registered users once the query succeeded.
+     */
+    getRegisteredUsers(callback: Function): void;
+
+    /**
+     * 
+     * @param sessionId -
+     *        Single user session ID or an array of those.
+     * @param options -
+     *        Input stream options.
+     * @returns Input stream
+     */
+    inputStreamForUser(sessionId: number | any[], options: Object): MumbleInputStream;
+
+    /**
+     * 
+     * This method must be invoked to start the authentication handshake. Once the
+     * handshake is done the client emits `initialized` event and the rest of the
+     * functionality will be available.
+     * @param name -
+     *        Username. Ignored for registered users who will use the username
+     *        registered with the certificate.
+     * @param password -
+     *        Optional password. Required if the username is in use and certificate
+     *        isn't supplied.
+     * @param tokens - list of ACL tokens to apply on connection
+     */
+    authenticate(name: string, password: string, tokens: string[]): void;
+
+    /**
+     * 
+     * Previously a method with the same name was used to send raw Mumble protocol
+     * messages.  Use {@link MumbleConnection#sendMessage} for that now.
+     * @param message - The text to send.
+     * @param recipients - Target users.
+     * @param recipients.session - Session IDs of target users.
+     * @param recipients.channel_id - Channel IDs of target channels.
+     */
+    sendMessage(message: string, recipients: (sendMessage_recipients)[]): void;
+
+    /**
+     * 
+     * @param userid -
+     *        Optional user session ID. Defines the user whose audio the stream will
+     *        handle. If omitted the stream will output mixed audio.
+     * @returns - Output stream that can be used to stream the audio out.
+     */
+    outputStream(userid: number): MumbleOutputStream;
+
+    /**
+     * 
+     * @param options - Input stream options.
+     * @returns - Input stream for streaming audio to the server.
+     */
+    inputStream(options: Object): MumbleInputStream;
+
+    /**
+     * 
+     * @deprecated We should add "findByPath" method instead which can be used to
+     *             retrieve `Channel` instance.
+     * @param path - Path to join.
+     */
+    joinPath(path: string): void;
+
+    /**
+     * 
+     * Consider using the streams.
+     * @param chunk - 16bitLE PCM buffer of voice audio.
+     */
+    sendVoice(chunk: Buffer): void;
+
+    disconnect(): void;
+
 }
 
-export function connect(url: string, options: Options, callback: (err: Error, connection: Connection) => void): void;
+declare interface sendMessage_recipients {
+    /**
+     * Session IDs of target users.
+     */
+    session: number[];
+    /**
+     * Channel IDs of target channels.
+     */
+    channel_id: number[];
+}
+
+declare class MumbleConnection {
+    /**
+     * Mumble connection
+     * @param socket - SSL socket connected to the server.
+     * @param options - Connection options.
+     */
+    constructor(socket: Socket, options: Object);
+
+    /**
+     * Send the static init information
+     */
+    initialize(): void;
+
+    /**
+     * Authenticate the user
+     * @param name - Username
+     * @param password - User password
+     * @param tokens - Access tokens
+     */
+    authenticate(name: string, password: string, tokens: string[]): void;
+
+    /**
+     * Send a protocol message
+     * @param type Message type ID
+     * @param data Message data
+     */
+    sendMessage(type: string, data: Object): void;
+
+    /**
+     * Returns a new output stream for audio.
+     * @param userSession Optional user session ID. If omitted the output stream will receive
+     *        the mixed audio output for all users.
+     * @param noEmptyFrames Enable or disable emitting empty frames for silence.
+     * @returns Output stream.
+     */
+    outputStream(userSession: number, noEmptyFrames: boolean): MumbleOutputStream;
+
+    /**
+     * Returns a new input stream for audio.
+     * @param options - Input stream options
+     * @returns Input stream.
+     */
+    inputStream(options: Object): MumbleInputStream;
+
+    /**
+     * Join a channel specified by a Mumble URL
+     * @param path - Path to join.
+     */
+    joinPath(path: string): void;
+
+    /**
+     * Send voice data to the server.
+     * 
+     * TODO: Add a flush timeout to flush remaining audio data if
+     * the buffer contains remnant data.
+     * @param chunk - PCM audio data in 16bit unsigned LE format.
+     * @param whisperTarget - Optional whisper target ID.
+     */
+    sendVoice(chunk: Buffer, whisperTarget: number): void;
+
+    /**
+     * 
+     * @param frame - Voice frame.
+     *        The buffer must be the size of a one frame.
+     *        Use sendVoice to send arbitrary length buffers.
+     * @param whisperTarget - Optional whisper target ID. Defaults to null.
+     * @param voiceSequence -
+     *        Voice packet sequence number. Required when multiplexing several audio
+     *        streams to different users.
+     * @returns Frames sent
+     */
+    sendVoiceFrame(frame: Buffer, whisperTarget?: number, voiceSequence?: number): Buffer;
+
+    /**
+     * 
+     * @param packets - Encoded frames.
+     * @param codec - Audio codec number for the packets.
+     * @param whisperTarget - Optional whisper target ID. Defaults to null.
+     * @param voiceSequence -
+     *        Voice packet sequence number. Required when multiplexing several audio
+     *        streams to different users.
+     * @returns Amount of frames sent.
+     */
+    sendEncodedFrame(packets: Buffer, codec: number, whisperTarget?: number, voiceSequence?: number): number;
+
+    /**
+     * Disconnects the client from Mumble
+     */
+    disconnect(): void;
+
+}
+
+/**
+ * Encodes the version to an uint8 that can be sent to the server for version-exchange
+ * @param major - Major version.
+ * @param minor - Minor version.
+ * @param patch - Patch number.
+ * @returns 32-bit encoded version number.
+ */
+declare function encodeVersion(major: number, minor: number, patch: number): number;
+
+declare class MumbleConnectionManager {
+    /**
+     * 
+     * A connection tool to decouple connecting to the server
+     * from the module itself.
+     * 
+     * The URL specified to the connection manager the Mumble server address.
+     * It can be either host with optional port specified with `host:port`
+     * or then the full `mumble://`.
+     * @param url - Mumble server address.
+     * @param options - TLS options.
+     */
+    constructor(url: string, options: Object);
+
+    /**
+     * 
+     * Connects to the Mumble server provided in the constructor
+     * @param done Connection callback receiving {@link MumbleClient}.
+     */
+    connect(done: Function): void;
+
+}
+
+/**
+ * Error class for delivering server errors.
+ * @param name - Error type name.
+ * @param data - Error data.
+ */
+declare function MumbleError(name: string, data: Object): void;
+
+declare class MumbleInputStream extends Writable {
+    /**
+     * 
+     * The stream implements the `WritableStream` interface.
+     * 
+     * The input data format can be specified with the constructor options. The
+     * final audio will be converted to mono 16-bit PCM at 48 kHz.
+     * 
+     * Currently the packets are sent to murmur in 10ms packets. The sample rate
+     * should be such that it can divide the audio to packets of that size.
+     * @param connection Mumble connection to write to
+     * @param options - Stream options.
+     * @param options.sampleRate - Input sample rate. Defaults to 48000.
+     * @param options.channels - Input channels. Defaults to 1.
+     * @param options.gain - Volume multiplier. Defaults to 1.
+     */
+    constructor(connection: MumbleConnection, options?: undefined_options);
+
+    close(): void;
+
+    /**
+     * 
+     * @param gain - New gain value.
+     */
+    setGain(gain: number): void;
+
+}
+
+declare interface undefined_options {
+    /**
+     * Input sample rate. Defaults to 48000.
+     */
+    sampleRate: number;
+    /**
+     * Input channels. Defaults to 1.
+     */
+    channels: number;
+    /**
+     * Volume multiplier. Defaults to 1.
+     */
+    gain: number;
+}
+
+declare class MumbleOutputStream extends Readable {
+    /**
+     * 
+     * The stream implements the `ReadableStream` interface
+     * 
+     * The output data will be 16-bit PCM at 48 kHz. There's no options to resample
+     * it like there are for the InputStream.
+     * @param connection - Mumble connection to read from.
+     * @param sessionId - User session ID.
+     * @param options - Stream options.
+     */
+    constructor(connection: MumbleConnection, sessionId: number, options: Object);
+
+    close(): void;
+
+    /**
+     * ReadableStream _read implementation
+     * 
+     * This method is called by the ReadableStream when it requests more data.
+     * @param size Number of bytes to read
+     */
+    _read(size: number): void;
+
+}
+
+declare class MumbleSocket {
+    /**
+     * Mumble network protocol wrapper for an SSL socket
+     * @param socket SSL socket to be wrapped.
+     *        The socket must be connected to the Mumble server.
+     */
+    constructor(socket: Socket);
+
+    /**
+     * Handle incoming data from the socket
+     * @param data Incoming data buffer
+     */
+    receiveData(data: Buffer): void;
+
+    /**
+     * Queue a reader callback for incoming data.
+     * @param length The amount of data this callback expects
+     * @param callback The data callback
+     */
+    read(length: number, callback: Function): void;
+
+    /**
+     * Write message into the socket
+     * @param buffer Message to write
+     */
+    write(buffer: Buffer): void;
+
+    /**
+     * Close the socket
+     */
+    end(): void;
+
+}
+
+declare class User {
+    /**
+     * Single user on the server.
+     * @param data - User data.
+     * @param client - Mumble client that owns this user.
+     */
+    constructor(data: Object, client: MumbleClient);
+
+    /**
+     * 
+     * @param channel - Channel name or a channel object
+     */
+    moveToChannel(channel: Channel | string): void;
+
+    /**
+     * 
+     * @param comment - The new comment
+     */
+    setComment(comment: String): void;
+
+    /**
+     * 
+     * @param isSelfDeaf - The new self deafened state
+     */
+    setSelfDeaf(isSelfDeaf: Boolean): void;
+
+    /**
+     * 
+     * @param isSelfMute - The new self muted state
+     */
+    setSelfMute(isSelfMute: Boolean): void;
+
+    /**
+     * 
+     * @param reason - The reason to kick the user for.
+     */
+    kick(reason?: string): void;
+
+    /**
+     * 
+     * @param reason - The reason to ban the user for.
+     */
+    ban(reason?: string): void;
+
+    /**
+     * 
+     * @param message - The message to send.
+     */
+    sendMessage(message: string): void;
+
+    /**
+     * 
+     * @param noEmptyFrames True to cut the output stream during silence. If the output stream
+     *        isn't cut it will keep emitting zero-values when the user isn't
+     *        talking.
+     * @returns Output stream.
+     */
+    outputStream(noEmptyFrames?: Boolean): MumbleOutputStream;
+
+    /**
+     * 
+     * @returns Input stream.
+     */
+    inputStream(): MumbleInputStream;
+
+    /**
+     * 
+     * @returns True if the user can talk.
+     */
+    canTalk(): Boolean;
+
+    register(): void;
+
+    /**
+     * 
+     * @returns True if the user can hear.
+     */
+    canHear(): Boolean;
+
+    /**
+     * 
+     * @returns _true_ if the user is registered.
+     */
+    isRegistered(): Boolean;
+
+    /**
+     * 
+     * Session ID is present for all users. The ID specifies the current user
+     * session and will change when the user reconnects.
+     * @see User#id
+     */
+    session: Number;
+
+    name: String;
+
+    /**
+     * 
+     * User ID is specified only for users who are registered on the server.
+     * The user ID won't change when the user reconnects.
+     * @see User#session
+     */
+    id: Number;
+
+    mute: Boolean;
+
+    deaf: Boolean;
+
+    /**
+     * 
+     * The user will be suppressed by the server if they don't have permissions
+     * to speak on the current channel.
+     */
+    suppress: Boolean;
+
+    selfMute: Boolean;
+
+    selfDeaf: Boolean;
+
+    hash: String;
+
+    recording: Boolean;
+
+    prioritySpeaker: Boolean;
+
+    channel: Channel;
+
+}
+
+/**
+ * 
+ * @see
+ * @param i - Integer to convert
+ * @returns Varint encoded number
+ */
+declare function toVarint(i: number): Buffer;
+
+/**
+ * 
+ * @see
+ * @param b - Varint to convert
+ * @returns Decoded integer
+ */
+declare function fromVarint(b: Buffer): number;
+
+/**
+ * 
+ * @param permissionFlags - Permission bit flags
+ * @returns Permission object with the bit flags decoded.
+ */
+declare function readPermissions(permissionFlags: number): Object;
+
+/**
+ * 
+ * @param permissionObject - Permissions object
+ * @returns Permission bit flags
+ */
+declare function writePermissions(permissionObject: Object): number;
+
+/**
+ * Applies gain to the audio frame. Modifies the frame.
+ * @param frame - Audio frame with 16-bit samples.
+ * @param gain - Multiplier for each sample.
+ * @returns The audio frame passed in.
+ */
+declare function applyGain(frame: Buffer, gain: number): Buffer;
+
+/**
+ * Downmixes multi-channel frame to mono.
+ * @param frame - Multi-channel audio frame.
+ * @param channels - Number of channels.
+ * @returns Downmixed audio frame.
+ */
+declare function downmixChannels(frame: Buffer, channels: number): Buffer;
+
+/**
+ * 
+ * The resampling is done by duplicating samples every now and then so it's not
+ * the best quality. Also the source/target rate conversion must result in a
+ * whole number of samples for the frame size.
+ * @param frame - Original frame
+ * @param sourceRate - Original sample rate
+ * @param targetRate - Target sample rate
+ * @returns New resampled buffer.
+ */
+declare function resample(frame: Buffer, sourceRate: number, targetRate: number): Buffer;
+
+/**
+ * 
+ * Assuming both source and target Bit depth are multiples of eight, this
+ * function rescales the frame. E.g. it can be used to make a 16 Bit audio
+ * frame of an 8 Bit audio frame.
+ * @param frame - Original frame
+ * @param sourceDepth - Original Bit depth
+ * @param sourceUnsigned - whether the source values are unsigned
+ * @param sourceBE - whether the source values are big endian
+ * @returns Rescaled buffer.
+ */
+declare function rescaleToUInt16LE(frame: Buffer, sourceDepth: number, sourceUnsigned: Boolean, sourceBE: Boolean): Buffer;
+

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,10 @@ declare class Channel {
 
     users: User[];
 
+    id: number;
+
+    name: string;
+
     join(): void;
 
     /**
@@ -40,7 +44,7 @@ declare class Channel {
 
 }
 
-declare class MumbleClient {
+declare class MumbleClient extends EventEmitter {
     /**
      * 
      * Instances should be created with Mumble.connect().
@@ -466,19 +470,19 @@ declare class User {
      * 
      * @param comment - The new comment
      */
-    setComment(comment: String): void;
+    setComment(comment: string): void;
 
     /**
      * 
      * @param isSelfDeaf - The new self deafened state
      */
-    setSelfDeaf(isSelfDeaf: Boolean): void;
+    setSelfDeaf(isSelfDeaf: boolean): void;
 
     /**
      * 
      * @param isSelfMute - The new self muted state
      */
-    setSelfMute(isSelfMute: Boolean): void;
+    setSelfMute(isSelfMute: boolean): void;
 
     /**
      * 
@@ -505,7 +509,7 @@ declare class User {
      *        talking.
      * @returns Output stream.
      */
-    outputStream(noEmptyFrames?: Boolean): MumbleOutputStream;
+    outputStream(noEmptyFrames?: boolean): MumbleOutputStream;
 
     /**
      * 
@@ -517,7 +521,7 @@ declare class User {
      * 
      * @returns True if the user can talk.
      */
-    canTalk(): Boolean;
+    canTalk(): boolean;
 
     register(): void;
 
@@ -525,13 +529,13 @@ declare class User {
      * 
      * @returns True if the user can hear.
      */
-    canHear(): Boolean;
+    canHear(): boolean;
 
     /**
      * 
      * @returns _true_ if the user is registered.
      */
-    isRegistered(): Boolean;
+    isRegistered(): boolean;
 
     /**
      * 
@@ -539,9 +543,9 @@ declare class User {
      * session and will change when the user reconnects.
      * @see User#id
      */
-    session: Number;
+    session: number;
 
-    name: String;
+    name: string;
 
     /**
      * 
@@ -549,28 +553,28 @@ declare class User {
      * The user ID won't change when the user reconnects.
      * @see User#session
      */
-    id: Number;
+    id: number;
 
-    mute: Boolean;
+    mute: boolean;
 
-    deaf: Boolean;
+    deaf: boolean;
 
     /**
      * 
      * The user will be suppressed by the server if they don't have permissions
      * to speak on the current channel.
      */
-    suppress: Boolean;
+    suppress: boolean;
 
-    selfMute: Boolean;
+    selfMute: boolean;
 
-    selfDeaf: Boolean;
+    selfDeaf: boolean;
 
-    hash: String;
+    hash: string;
 
-    recording: Boolean;
+    recording: boolean;
 
-    prioritySpeaker: Boolean;
+    prioritySpeaker: boolean;
 
     channel: Channel;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -57,7 +57,7 @@ declare class MumbleClient extends EventEmitter {
      * The connection is considered `ready` when the server handshake has been
      * processed and the initial ping has been received.
      */
-    ready: Boolean;
+    ready: boolean;
 
     /**
      * 
@@ -164,7 +164,7 @@ declare class MumbleClient extends EventEmitter {
      * @param recipients.session - Session IDs of target users.
      * @param recipients.channel_id - Channel IDs of target channels.
      */
-    sendMessage(message: string, recipients: (sendMessage_recipients)[]): void;
+    sendMessage(message: string, recipients: sendMessage_recipients): void;
 
     /**
      * 
@@ -649,5 +649,5 @@ declare function resample(frame: Buffer, sourceRate: number, targetRate: number)
  * @param sourceBE - whether the source values are big endian
  * @returns Rescaled buffer.
  */
-declare function rescaleToUInt16LE(frame: Buffer, sourceDepth: number, sourceUnsigned: Boolean, sourceBE: Boolean): Buffer;
+declare function rescaleToUInt16LE(frame: Buffer, sourceDepth: number, sourceUnsigned: boolean, sourceBE: boolean): Buffer;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "events"; 
 import { Socket } from "net"; 
 import { Writable, Readable } from "stream"; 
 declare class Channel {
@@ -207,7 +208,7 @@ declare interface sendMessage_recipients {
     channel_id: number[];
 }
 
-declare class MumbleConnection {
+declare class MumbleConnection extends EventEmitter {
     /**
      * Mumble connection
      * @param socket - SSL socket connected to the server.
@@ -327,9 +328,16 @@ declare class MumbleConnectionManager {
      * Connects to the Mumble server provided in the constructor
      * @param done Connection callback receiving {@link MumbleClient}.
      */
-    connect(done: Function): void;
+    connect(done: ConnectionCallback): void;
 
 }
+
+/**
+ * 
+ * @param err - An error of one occured
+ * @param client - The mumble client for the connection
+ */
+declare type ConnectionCallback = (err: Error | null, client: MumbleClient)=>void;
 
 /**
  * Error class for delivering server errors.

--- a/lib/Channel.js
+++ b/lib/Channel.js
@@ -7,6 +7,8 @@ var EventEmitter = require( 'events' ).EventEmitter;
 /**
  * Single channel on the server.
  *
+ * @class
+ *
  * @param {Object} data - Channel data.
  * @param {MumbleClient} client - Mumble client that owns the channel.
  */

--- a/lib/Channel.js
+++ b/lib/Channel.js
@@ -8,6 +8,7 @@ var EventEmitter = require( 'events' ).EventEmitter;
  * Single channel on the server.
  *
  * @class
+ * @extends EventEmitter
  *
  * @param {Object} data - Channel data.
  * @param {MumbleClient} client - Mumble client that owns the channel.
@@ -45,8 +46,19 @@ var Channel = function( data, client ) {
 
     // TODO: Description
 };
-
 Channel.prototype = Object.create( EventEmitter.prototype );
+
+/**
+ * @name id
+ * @type {number}
+ * @memberof Channel#
+ */
+
+/**
+ * @name name
+ * @type {string}
+ * @memberof Channel#
+ */
 
 /**
  * @summary Join the channel

--- a/lib/MumbleClient.js
+++ b/lib/MumbleClient.js
@@ -358,7 +358,7 @@ MumbleClient.prototype.authenticate = function( name, password, tokens ) {
  * messages.  Use {@link MumbleConnection#sendMessage} for that now.
  *
  * @param {string} message - The text to send.
- * @param {Object[]} recipients - Target users.
+ * @param {Object} recipients - Target users.
  * @param {number[]} recipients.session - Session IDs of target users.
  * @param {number[]} recipients.channel_id - Channel IDs of target channels.
  */

--- a/lib/MumbleClient.js
+++ b/lib/MumbleClient.js
@@ -32,7 +32,7 @@ var MumbleClient = function( connection ) {
      * processed and the initial ping has been received.
      *
      * @name MumbleClient#ready
-     * @type Boolean
+     * @type boolean
      */
     this.ready = false;
 

--- a/lib/MumbleClient.js
+++ b/lib/MumbleClient.js
@@ -8,6 +8,7 @@ var EventEmitter = require( 'events' ).EventEmitter;
 var util = require( './util' );
 
 /**
+ * @class
  * @summary Mumble client API
  *
  * @description
@@ -402,7 +403,7 @@ MumbleClient.prototype.outputStream = function( userid ) {
  *
  * @param {Object} options - Input stream options.
  *
- * @returns {MumbleInputSTream} -
+ * @returns {MumbleInputStream} -
  *      Input stream for streaming audio to the server.
  */
 MumbleClient.prototype.inputStream = function( options ) {

--- a/lib/MumbleConnection.js
+++ b/lib/MumbleConnection.js
@@ -17,6 +17,7 @@ var EventEmitter = require( 'events' ).EventEmitter;
  * Mumble connection
  *
  * @class
+ * @extends EventEmitter
  *
  * @param {Socket} socket - SSL socket connected to the server.
  * @param {Object} options - Connection options.

--- a/lib/MumbleConnection.js
+++ b/lib/MumbleConnection.js
@@ -16,6 +16,8 @@ var EventEmitter = require( 'events' ).EventEmitter;
 /**
  * Mumble connection
  *
+ * @class
+ *
  * @param {Socket} socket - SSL socket connected to the server.
  * @param {Object} options - Connection options.
  **/

--- a/lib/MumbleConnectionManager.js
+++ b/lib/MumbleConnectionManager.js
@@ -38,12 +38,19 @@ var MumbleConnectionManager = function( url, options ) {
 };
 
 /**
+ * @typedef {Function} ConnectionCallback
+ *
+ * @param {Error|null} err - An error of one occured
+ * @param {MumbleClient} client - The mumble client for the connection
+ */
+
+/**
  * @summary Connect to the Mumble server.
  *
  * @description
  * Connects to the Mumble server provided in the constructor
  *
- * @param {function(err,client)} done
+ * @param {ConnectionCallback} done
  *      Connection callback receiving {@link MumbleClient}.
  */
 MumbleConnectionManager.prototype.connect = function connect( done ) {

--- a/lib/MumbleInputStream.js
+++ b/lib/MumbleInputStream.js
@@ -9,6 +9,9 @@ var util = require( './util' );
 /**
  * @summary Input stream for sending audio to Mumble.
  *
+ * @class
+ * @extends module:stream/Writable
+ *
  * @description
  * The stream implements the `WritableStream` interface.
  *
@@ -18,13 +21,14 @@ var util = require( './util' );
  * Currently the packets are sent to murmur in 10ms packets. The sample rate
  * should be such that it can divide the audio to packets of that size.
  *
+ *
  * @constructor
  * @this {MumbleInputStream}
  * @param {MumbleConnection} connection Mumble connection to write to
  * @param {Object} options - Stream options.
- * @param {number} options.sampleRate - Input sample rate. Defaults to 48000.
- * @param {number} options.channels - Input channels. Defaults to 1.
- * @param {number} options.gain - Volume multiplier. Defaults to 1.
+ * @param {number} [options.sampleRate=48000] - Input sample rate. Defaults to 48000.
+ * @param {number} [options.channels=1] - Input channels. Defaults to 1.
+ * @param {number} [options.gain=1] - Volume multiplier. Defaults to 1.
  */
 var MumbleInputStream = function( connection, options ) {
 

--- a/lib/MumbleSocket.js
+++ b/lib/MumbleSocket.js
@@ -63,8 +63,9 @@ MumbleSocket.prototype.read = function( length, callback ) {
  * @param {Buffer} buffer Message to write
  */
 MumbleSocket.prototype.write = function( buffer ) {
-    // Just in case the function is call when we are disconnecting, we need to check if the socket is still writable
-    if(this.socket.writable) {
+    // Just in case the function is call when we are disconnecting,
+    // we need to check if the socket is still writable
+    if( this.socket.writable ) {
         this.socket.write( buffer );
     }
 };

--- a/lib/MumbleSocket.js
+++ b/lib/MumbleSocket.js
@@ -4,7 +4,7 @@
 /**
  * Mumble network protocol wrapper for an SSL socket
  *
- * @private
+ * @class
  *
  * @constructor
  * @this {MumbleSocket}

--- a/lib/User.js
+++ b/lib/User.js
@@ -7,6 +7,8 @@ var util = require( './util' );
 /**
  * Single user on the server.
  *
+ * @class
+ *
  * @param {Object} data - User data.
  * @param {MumbleClient} client - Mumble client that owns this user.
  */
@@ -116,7 +118,7 @@ User.prototype.outputStream = function( noEmptyFrames ) {
  * @returns {MumbleInputStream} Input stream.
  */
 User.prototype.inputStream = function() {
-    return this.client.inputStreamForUser( this.session );
+    return this.client.inputStreamForUser( this.session, {} );
 };
 
 /**

--- a/lib/User.js
+++ b/lib/User.js
@@ -44,7 +44,7 @@ User.prototype.moveToChannel = function( channel ) {
 /**
  * @summary Set the user's comment. Displayed when user's name is hovered over in client.
  *
- * @param {String} comment - The new comment
+ * @param {string} comment - The new comment
  */
 User.prototype.setComment = function( comment ) {
     this.client.connection.sendMessage( 'UserState', {
@@ -54,7 +54,7 @@ User.prototype.setComment = function( comment ) {
 /**
  * @summary Change a user's self deafened state. (Obviously) only works on yourself.
  *
- * @param {Boolean} isSelfDeaf - The new self deafened state
+ * @param {boolean} isSelfDeaf - The new self deafened state
  */
 User.prototype.setSelfDeaf = function( isSelfDeaf ) {
     this.client.connection.sendMessage( 'UserState', {
@@ -64,7 +64,7 @@ User.prototype.setSelfDeaf = function( isSelfDeaf ) {
 /**
  * @summary Change a user's self muted state. (Obviously) only works on yourself.
  *
- * @param {Boolean} isSelfMute - The new self muted state
+ * @param {boolean} isSelfMute - The new self muted state
  */
 User.prototype.setSelfMute = function( isSelfMute ) {
     this.client.connection.sendMessage( 'UserState', {
@@ -101,7 +101,7 @@ User.prototype.sendMessage = function( message ) {
 /**
  * @summary Returns an output stream for listening to the user audio.
  *
- * @param {Boolean} [noEmptyFrames]
+ * @param {boolean} [noEmptyFrames]
  *      True to cut the output stream during silence. If the output stream
  *      isn't cut it will keep emitting zero-values when the user isn't
  *      talking.
@@ -124,7 +124,7 @@ User.prototype.inputStream = function() {
 /**
  * @summary Checks whether the user can talk or not.
  *
- * @returns {Boolean} True if the user can talk.
+ * @returns {boolean} True if the user can talk.
  */
 User.prototype.canTalk = function() {
     return !this.mute && !this.selfMute && !this.suppress;
@@ -152,7 +152,7 @@ User.prototype.register = function() {
 /**
  * @summary Checks whether the user can hear other people.
  *
- * @returns {Boolean} True if the user can hear.
+ * @returns {boolean} True if the user can hear.
  */
 User.prototype.canHear = function() {
     return !this.selfDeaf;
@@ -161,7 +161,7 @@ User.prototype.canHear = function() {
 /**
  * @summary _true_ when the user is registered on the server.
  *
- * @returns {Boolean} _true_ if the user is registered.
+ * @returns {boolean} _true_ if the user is registered.
  */
 User.prototype.isRegistered = function() {
     return !!this.id;
@@ -179,7 +179,7 @@ User.prototype._applyProperties = function( data ) {
      * @see User#id
      *
      * @name User#session
-     * @type Number
+     * @type number
      */
     this.session = data.session;
 
@@ -187,7 +187,7 @@ User.prototype._applyProperties = function( data ) {
      * @summary User name
      *
      * @name User#name
-     * @type String
+     * @type string
      */
     this.name = data.name;
 
@@ -201,7 +201,7 @@ User.prototype._applyProperties = function( data ) {
      * @see User#session
      *
      * @name User#id
-     * @type Number
+     * @type number
      */
     this.id = data.user_id;
 
@@ -209,7 +209,7 @@ User.prototype._applyProperties = function( data ) {
      * @summary _true_ when the user is muted by an admin.
      *
      * @name User#mute
-     * @type Boolean
+     * @type boolean
      */
     this.mute = data.mute;
 
@@ -217,7 +217,7 @@ User.prototype._applyProperties = function( data ) {
      * @summary _true_ when the user is deafened by an admin.
      *
      * @name User#deaf
-     * @type Boolean
+     * @type boolean
      */
     this.deaf = data.deaf;
 
@@ -230,7 +230,7 @@ User.prototype._applyProperties = function( data ) {
      * to speak on the current channel.
      *
      * @name User#suppress
-     * @type Boolean
+     * @type boolean
      */
     this.suppress = data.suppress;
 
@@ -238,7 +238,7 @@ User.prototype._applyProperties = function( data ) {
      * @summary _true_ when the user has muted themselves.
      *
      * @name User#selfMute
-     * @type Boolean
+     * @type boolean
      */
     this.selfMute = data.self_mute;
 
@@ -246,7 +246,7 @@ User.prototype._applyProperties = function( data ) {
      * @summary _true_ when the user has deafened themselves.
      *
      * @name User#selfDeaf
-     * @type Boolean
+     * @type boolean
      */
     this.selfDeaf = data.self_deaf;
 
@@ -254,7 +254,7 @@ User.prototype._applyProperties = function( data ) {
      * @summary The hash of the user certificate
      *
      * @name User#hash
-     * @type String
+     * @type string
      */
     this.hash = data.hash;
 
@@ -262,7 +262,7 @@ User.prototype._applyProperties = function( data ) {
      * @summary _true_ when the user is recording the conversation.
      *
      * @name User#recording
-     * @type Boolean
+     * @type boolean
      */
     this.recording = data.recording;
 
@@ -270,7 +270,7 @@ User.prototype._applyProperties = function( data ) {
      * @summary _true_ when the user is a priority speaker.
      *
      * @name User#prioritySpeaker
-     * @type Boolean
+     * @type boolean
      */
     this.prioritySpeaker = data.priority_speaker;
 
@@ -347,7 +347,7 @@ User.prototype._checkChangeChannel = function( data ) {
  * Also available through the client `user-mute` event.
  *
  * @event User#mute
- * @param {Boolean} status
+ * @param {boolean} status
  *      True when the user is muted, false when unmuted.
  */
 
@@ -358,7 +358,7 @@ User.prototype._checkChangeChannel = function( data ) {
  * Also available through the client `user-self-mute` event.
  *
  * @event User#self-mute
- * @param {Boolean} status
+ * @param {boolean} status
  *      True when the user mutes themselves. False when unmuting.
  */
 
@@ -369,7 +369,7 @@ User.prototype._checkChangeChannel = function( data ) {
  * Also available through the client `user-self-deaf` event.
  *
  * @event User#self-deaf
- * @param {Boolean} status
+ * @param {boolean} status
  *      True when the user deafens themselves. False when undeafening.
  */
 
@@ -380,7 +380,7 @@ User.prototype._checkChangeChannel = function( data ) {
  * Also available through the client `user-suppress` event.
  *
  * @event User#suppress
- * @param {Boolean} status
+ * @param {boolean} status
  *      True when the user is suppressed. False when unsuppressed.
  */
 
@@ -391,7 +391,7 @@ User.prototype._checkChangeChannel = function( data ) {
  * Also available through the client `user-recording` event.
  *
  * @event User#recording
- * @param {Boolean} status
+ * @param {boolean} status
  *      True when the user starts recording. False when they stop.
  */
 
@@ -402,7 +402,7 @@ User.prototype._checkChangeChannel = function( data ) {
  * Also available through the client `user-priority-speaker` event.
  *
  * @event User#priority-speaker
- * @param {Boolean} status
+ * @param {boolean} status
  *      True when the user gains priority speaker status. False when they lose
  *      it.
  */

--- a/lib/util.js
+++ b/lib/util.js
@@ -336,8 +336,8 @@ exports.resample = function( frame, sourceRate, targetRate ) {
  *
  * @param {Buffer} frame - Original frame
  * @param {number} sourceDepth - Original Bit depth
- * @param {Boolean} sourceUnsigned - whether the source values are unsigned
- * @param {Boolean} sourceBE - whether the source values are big endian
+ * @param {boolean} sourceUnsigned - whether the source values are unsigned
+ * @param {boolean} sourceBE - whether the source values are big endian
  *
  * @returns {Buffer} Rescaled buffer.
  */

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "jitterbuffer": "^0.1.12"
   },
   "devDependencies": {
+    "@otris/jsdoc-tsd": "^1.0.4",
+    "@types/node": "^10.9.4",
     "chai": "^3.2.0",
     "chai-spies": "^0.7.0",
     "dmd-clean": "^0.1.0",
@@ -31,6 +33,8 @@
     "gulp-rename": "^1.2.2",
     "gulp-shell": "^0.4.1",
     "gulp-util": "^3.0.4",
-    "mocha": "^2.2.5"
+    "jsdoc": "^3.5.5",
+    "mocha": "^2.2.5",
+    "typescript": "^3.0.3"
   }
 }

--- a/update_typings.sh
+++ b/update_typings.sh
@@ -13,6 +13,7 @@ sed -i '1 i\import { EventEmitter } from "events"; ' ./index.d.ts
 sed -i -E "s/declare class MumbleInputStream/declare class MumbleInputStream extends Writable/g" ./index.d.ts
 sed -i -E "s/declare class MumbleOutputStream/declare class MumbleOutputStream extends Readable/g" ./index.d.ts
 sed -i -E "s/declare class MumbleConnection /declare class MumbleConnection extends EventEmitter /g" ./index.d.ts
+sed -i -E "s/declare class MumbleClient /declare class MumbleClient extends EventEmitter /g" ./index.d.ts
 
 set -e
 ./node_modules/.bin/tsc ./index.d.ts

--- a/update_typings.sh
+++ b/update_typings.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Generate typescript definitions from JSDoc comments
+./node_modules/.bin/jsdoc  -t node_modules/@otris/jsdoc-tsd -r ./lib -d ./index.d.ts 2>&1 | \
+    grep -v "Unsupported jsdoc item kind: event" # strip away error message for @event jsdoc comments (not supported)
+
+# Add imports for stream
+sed -i '1 i\import { Writable, Readable } from "stream"; ' ./index.d.ts
+sed -i '1 i\import { Socket } from "net"; ' ./index.d.ts
+
+# Fix classes that extend Writable/ReadableStream
+sed -i -E "s/declare class MumbleInputStream/declare class MumbleInputStream extends Writable/g" ./index.d.ts
+sed -i -E "s/declare class MumbleOutputStream/declare class MumbleOutputStream extends Readable/g" ./index.d.ts
+
+set -e
+./node_modules/.bin/tsc ./index.d.ts

--- a/update_typings.sh
+++ b/update_typings.sh
@@ -7,10 +7,12 @@
 # Add imports for stream
 sed -i '1 i\import { Writable, Readable } from "stream"; ' ./index.d.ts
 sed -i '1 i\import { Socket } from "net"; ' ./index.d.ts
+sed -i '1 i\import { EventEmitter } from "events"; ' ./index.d.ts
 
 # Fix classes that extend Writable/ReadableStream
 sed -i -E "s/declare class MumbleInputStream/declare class MumbleInputStream extends Writable/g" ./index.d.ts
 sed -i -E "s/declare class MumbleOutputStream/declare class MumbleOutputStream extends Readable/g" ./index.d.ts
+sed -i -E "s/declare class MumbleConnection /declare class MumbleConnection extends EventEmitter /g" ./index.d.ts
 
 set -e
 ./node_modules/.bin/tsc ./index.d.ts


### PR DESCRIPTION
As discussed in #110, this pull request fixes the `user.inputStream()` method and automates the generation of TypeScript declaration files (it should also fix the eslint errors on travis).

It also adds a few new devDependecies for `typescript` (validating the generated declaration file), `jsdoc` and [`@otris/jsdoc-tsd`](https://github.com/otris/jsdoc-tsd) for generating the declaration file.

Unfortunately https://github.com/otris/jsdoc-tsd does not yet support JSDoc's `@extends` so I need to create a script to fix the declaration file (i.e. `MumbeInputStream` and `MumbleOutputStream` correctly extend `stream.Writable` and `stream.Readable`). 
The script requires `grep` and `sed` to be installed when generating the typings (tried to avoid that but didn't found a reasonable way).

I'd be fine to help keeping them up-to-date.