### PR TITLE
Use a more conservative estimate of overhead

### DIFF
--- a/lib/MumbleConnection.js
+++ b/lib/MumbleConnection.js
@@ -629,8 +629,8 @@ MumbleConnection.prototype._onUserState = function( userState ) {
 MumbleConnection.prototype._onServerSync = function( syncData ) {
     this.sessionId = syncData.session;
 
-    // Overhead based on Mumble client settings at 10ms per packet.
-    var overhead = 29000;
+    // Overhead is an estimate based on watching the bandwidth section of the information screen
+    var overhead = 42000;
     this.setBitrate( syncData.max_bandwidth - overhead );
 };
 


### PR DESCRIPTION
The previous estimate based on the mumble client settings frequently caused skipping when trying to transmit audio. In order to prevent this, this commit makes the overhead estimate higher so the client will use a lower bitrate.

From my testing, a nodejs client with the bitrate set to 128,000 reached up to 165,400. To get to the overhead estimate I used here, I rounded 165,400 up to 170,000 to be safe, and subtracted 128,000.

This should fix https://github.com/Rantanen/node-mumble/issues/59